### PR TITLE
Initial DNS Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ sign.key
 /dist
 /pritunl_client.egg-info
 /tools/build_keys.json
+.idea/

--- a/data/scripts/update-resolv-conf.sh
+++ b/data/scripts/update-resolv-conf.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+#
+# Parses DHCP options from openvpn to update resolv.conf
+# To use set as 'up' and 'down' script in your openvpn *.conf:
+# up /etc/openvpn/update-resolv-conf
+# down /etc/openvpn/update-resolv-conf
+#
+# Used snippets of resolvconf script by Thomas Hood <jdthood@yahoo.co.uk>
+# and Chris Hanson
+# Licensed under the GNU GPL.  See /usr/share/common-licenses/GPL.
+# 07/2013 colin@daedrum.net Fixed intet name
+# 05/2006 chlauber@bnc.ch
+#
+# Example envs set from openvpn:
+# foreign_option_1='dhcp-option DNS 193.43.27.132'
+# foreign_option_2='dhcp-option DNS 193.43.27.133'
+# foreign_option_3='dhcp-option DOMAIN be.bnc.ch'
+# foreign_option_4='dhcp-option DOMAIN-SEARCH bnc.local'
+
+## You might need to set the path manually here, i.e.
+RESOLVCONF=`which resolvconf`
+if [[ -z "$RESOLVCONF" ]]; then
+  RESOLVCONF=/usr/bin/resolvconf
+fi
+
+[ -x "$RESOLVCONF" ] || exit 0
+
+case $script_type in
+
+up)
+  for optionname in ${!foreign_option_*} ; do
+    option="${!optionname}"
+    echo $option
+    part1=$(echo "$option" | cut -d " " -f 1)
+    if [ "$part1" == "dhcp-option" ] ; then
+      part2=$(echo "$option" | cut -d " " -f 2)
+      part3=$(echo "$option" | cut -d " " -f 3)
+      if [ "$part2" == "DNS" ] ; then
+        IF_DNS_NAMESERVERS="$IF_DNS_NAMESERVERS $part3"
+      fi
+      if [[ "$part2" == "DOMAIN" || "$part2" == "DOMAIN-SEARCH" ]] ; then
+        IF_DNS_SEARCH="$IF_DNS_SEARCH $part3"
+      fi
+    fi
+  done
+  R=""
+  if [ "$IF_DNS_SEARCH" ]; then
+    R="search "
+    for DS in $IF_DNS_SEARCH ; do
+      R="${R} $DS"
+    done
+  R="${R}
+"
+  fi
+
+  for NS in $IF_DNS_NAMESERVERS ; do
+    R="${R}nameserver $NS
+"
+  done
+  #echo -n "$R" | $RESOLVCONF -p -a "${dev}"
+  echo -n "$R" | $RESOLVCONF -a "${dev}.inet"
+  ;;
+down)
+  $RESOLVCONF -d "${dev}.inet"
+  ;;
+esac

--- a/pritunl_client/__main__.py
+++ b/pritunl_client/__main__.py
@@ -220,6 +220,7 @@ def client_shell():
     cli()
 
 def _pk_start(autostart=False):
+    from .constants import LINUX_ETC_DIR
     regex = r'(?:/pritunl_client/profiles/[a-z0-9]+\.ovpn)$'
     if not re.search(regex, sys.argv[1]):
         raise ValueError('Profile must be in home directory')
@@ -237,6 +238,12 @@ def _pk_start(autostart=False):
         os.chown(sys.argv[2], os.getuid(), os.getgid())
         args.append('--auth-user-pass')
         args.append(sys.argv[2])
+
+    # Handle DNS on Linux
+    # Currently only supports resolvconf / openresolv
+    args.extend(['--script-security', '2'])
+    args.extend(['--up', LINUX_ETC_DIR + '/update-resolv-conf.sh'])
+    args.extend(['--down', LINUX_ETC_DIR + '/update-resolv-conf.sh'])
 
     try:
         process = subprocess.Popen(args)

--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,9 @@ data_files += [
         os.path.join('data', 'var', 'pritunl-client.log'),
         os.path.join('data', 'var', 'pritunl-client.log.1'),
     ]),
+    (os.path.join(os.path.abspath(os.sep), 'etc', 'pritunl_client'), [
+        os.path.join('data', 'scripts', 'update-resolv-conf.sh'),
+    ])
 ]
 
 console_scripts = [


### PR DESCRIPTION
Added initial DNS support, currently supporting clients running resolvconf / openresolv.

(Reference pritunl/pritunl#191)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pritunl/pritunl-client/12)

<!-- Reviewable:end -->
