### PR TITLE
Starting VPN by name and enhancing daemon output

### DIFF
--- a/pritunl_client/shell_app.py
+++ b/pritunl_client/shell_app.py
@@ -238,5 +238,5 @@ class ShellApp(object):
 
             server.serve_forever()
         except socket_error:
-            logger.info('Address already in use. Make sure that port 9797 is
+            logger.info('Address already in use. Make sure that port 9797 is\
             available.', 'shell')

--- a/pritunl_client/shell_app.py
+++ b/pritunl_client/shell_app.py
@@ -9,6 +9,7 @@ import SocketServer
 import threading
 import json
 import httplib
+from socket import error as socket_error
 
 class ThreadingHTTPServer(SocketServer.ThreadingMixIn,
         BaseHTTPServer.HTTPServer):
@@ -226,12 +227,16 @@ class ShellApp(object):
                 args=(status_callback, connect_callback)).start()
 
     def start_server(self):
-        server = ThreadingHTTPServer(
-            ('127.0.0.1', 9797),
-            Request,
-        )
-        logger.info('Starting pritunl-client daemon...', 'shell')
+        try:
+            server = ThreadingHTTPServer(
+                ('127.0.0.1', 9797),
+                Request,
+            )
+            logger.info('Starting pritunl-client daemon...', 'shell')
 
-        self.autostart()
+            self.autostart()
 
-        server.serve_forever()
+            server.serve_forever()
+        except socket_error:
+            logger.info('Address already in use. Make sure that port 9797 is
+            available.', 'shell')


### PR DESCRIPTION
I have modified the code a little instead of displaying the whole trace to the user like this:

``` bash
Traceback (most recent call last):
  File "/bin/pritunl-client", line 9, in <module>
    load_entry_point('pritunl-client==1.0.894.98', 'console_scripts', 'pritunl-client')()
  File "/usr/lib/pritunl-client/lib/python2.7/site-packages/pritunl_client/__main__.py", line 222, in client_shell
    cli()
  File "/usr/lib/pritunl-client/lib/python2.7/site-packages/pritunl_client/click/core.py", line 663, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/pritunl-client/lib/python2.7/site-packages/pritunl_client/click/core.py", line 643, in main
    rv = self.invoke(ctx)
  File "/usr/lib/pritunl-client/lib/python2.7/site-packages/pritunl_client/click/core.py", line 990, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/pritunl-client/lib/python2.7/site-packages/pritunl_client/click/core.py", line 836, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/pritunl-client/lib/python2.7/site-packages/pritunl_client/click/core.py", line 463, in invoke
    return callback(*args, **kwargs)
  File "/usr/lib/pritunl-client/lib/python2.7/site-packages/pritunl_client/__main__.py", line 60, in daemon_cmd
    shell_app.ShellApp()
  File "/usr/lib/pritunl-client/lib/python2.7/site-packages/pritunl_client/shell_app.py", line 202, in __init__
    self.start_server()
  File "/usr/lib/pritunl-client/lib/python2.7/site-packages/pritunl_client/shell_app.py", line 231, in start_server
    Request,
  File "/usr/lib64/python2.7/SocketServer.py", line 420, in __init__
    self.server_bind()
  File "/usr/lib64/python2.7/BaseHTTPServer.py", line 108, in server_bind
    SocketServer.TCPServer.server_bind(self)
  File "/usr/lib64/python2.7/SocketServer.py", line 434, in server_bind
    self.socket.bind(self.server_address)
  File "/usr/lib64/python2.7/socket.py", line 228, in meth
    return getattr(self._sock,name)(*args)
socket.error: [Errno 98] Address already in use
```

when running:

``` bash
pritunl-client daemon
```

It will be as follows:

```
[2016-04-10 20:29:32,255][INFO] Address already in use. Make sure that port 9797 is available.
```

UPDATE:

I have added the ability to start vpn connection by name not just profile ID which should solve this #17

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pritunl/pritunl-client/20)

<!-- Reviewable:end -->
