### PR TITLE
Update resolvconf in shell platform

### DIFF
--- a/pritunl_client/profile_shell.py
+++ b/pritunl_client/profile_shell.py
@@ -33,6 +33,25 @@ class ProfileShell(profile.Profile):
                 passwd_file.write('pritunl_client\n')
                 passwd_file.write('%s\n' % passwd)
 
+        systemd_resolve = False
+        try:
+            subprocess.check_call(['which', 'systemd-resolve'])
+            with open('/etc/resolv.conf', 'r') as resolv_file:
+                data = resolv_file.read()
+                if 'systemd-resolved' in data or '127.0.0.53' in data:
+                    systemd_resolve = True
+        except:
+            pass
+        if systemd_resolve:
+            script_path = os.path.join(SHARE_DIR, 'update-systemd-resolved.sh')
+        else:
+            script_path = os.path.join(SHARE_DIR, 'update-resolv-conf.sh')
+
+        args.extend(['--script-security', '2'])
+        args.append('--up-restart')
+        args.extend(['--up', script_path])
+        args.extend(['--down', script_path])
+
         self._run_ovpn(status_callback, connect_callback, args, on_exit, False)
 
     def _start_autostart(self, status_callback, connect_callback, auth_token):


### PR DESCRIPTION
`pritunl-client` currently only updates resolvconf/systemd-resolve in graphical mode. This PR contains proof-of-content support for the shell platform.

Note that this duplicates logic from `__main__.py`, which is suboptimal. I'm not super familiar with the structure of this package, and don't see a good place to migrate the common code to that doesn't introduce a new module.

I'm also not sure what the purpose of [these arguments](https://github.com/pritunl/pritunl-client/blob/d7952495e7a52c8a453a73b3eb42c04be585f3e3/pritunl_client/__main__.py#L299-L302) passed to OpenVPN are, and seeing as they aren't passed in the existing shell platform I omitted them. They might need to be re-introduced.